### PR TITLE
angular ssr

### DIFF
--- a/src/ng5-slider/lib/slider.component.ts
+++ b/src/ng5-slider/lib/slider.component.ts
@@ -92,7 +92,7 @@ export class SliderElement extends JqLiteWrapper {
 
   constructor(elemRef: ElementRef, renderer: Renderer2, @Inject(PLATFORM_ID) private platformId) {
     super(elemRef, renderer);
-    this.isBrowser = platformId;
+    this.isBrowser = isPlatformBrowser(platformId);
   }
 }
 
@@ -1561,7 +1561,7 @@ export class SliderComponent implements OnInit, AfterViewInit, OnChanges, OnDest
 
   // Calculate element's width/height depending on whether slider is horizontal or vertical
   private calculateElementDimension(elem: SliderElement): void {
-//     TODO: if (this.isBrowser){ DO ANY ELEMENT getBoundingClientRect}
+//     TODO: if (this.isBrowser){ DO ANY ELEMENT getBoundingClientRect or dom manipulation which are not important for ssr }
     const val: ClientRect = elem.getBoundingClientRect();
     if (this.viewOptions.vertical) {
       elem.dimension = (val.bottom - val.top) * this.viewOptions.scale;

--- a/src/ng5-slider/lib/slider.component.ts
+++ b/src/ng5-slider/lib/slider.component.ts
@@ -17,8 +17,12 @@ import {
   TemplateRef,
   ChangeDetectorRef,
   SimpleChanges,
-  forwardRef
+  forwardRef,
+  PLATFORM_ID,
+  Inject
 } from '@angular/core';
+
+import {isPlatformBrowser} from '@angular/common';
 
 import {
   ControlValueAccessor, NG_VALUE_ACCESSOR
@@ -80,13 +84,15 @@ enum HandleLabelType {
 
 // TODO: slowly rewrite to angular
 export class SliderElement extends JqLiteWrapper {
+  isBrowser: boolean;
   position: number = 0;
   value: string; // TODO: this only applies to label elements; it should be moved to the specific directives where it's used
   dimension: number;
   alwaysHide: boolean = false;
 
-  constructor(elemRef: ElementRef, renderer: Renderer2) {
+  constructor(elemRef: ElementRef, renderer: Renderer2, @Inject(PLATFORM_ID) private platformId) {
     super(elemRef, renderer);
+    this.isBrowser = platformId;
   }
 }
 
@@ -1555,6 +1561,7 @@ export class SliderComponent implements OnInit, AfterViewInit, OnChanges, OnDest
 
   // Calculate element's width/height depending on whether slider is horizontal or vertical
   private calculateElementDimension(elem: SliderElement): void {
+//     TODO: if (this.isBrowser){ DO ANY ELEMENT getBoundingClientRect}
     const val: ClientRect = elem.getBoundingClientRect();
     if (this.viewOptions.vertical) {
       elem.dimension = (val.bottom - val.top) * this.viewOptions.scale;


### PR DESCRIPTION
I'm using ng5-slider and angular universal (SSR)
i always get this error in the server renderer log:

 ERROR TypeError: this.elemRef.nativeElement.getBoundingClientRect is not a function
0|server   |     at MinHDirective.JqLiteWrapper.getBoundingClientRect (/home/ubuntu/shoperr-shops/node_modules/ng5-slider/bundles/ng:/ng5-slider/out/jq-lite-wrapper.ts:49:39)

i fixed a lot of issues like these before by preventing blocks of js to be read by the renderer as i show in this pull request, it still needs some wrapping of DOM, window or document manipulations by using this.isBrowser as i show in the pull request.

Please help me continue this