### PR TITLE
fix "Tick values are displayed even if showTicksValues option is set to false (#105)"

### DIFF
--- a/src/ng5-slider/lib/slider.component.ts
+++ b/src/ng5-slider/lib/slider.component.ts
@@ -1243,7 +1243,7 @@ export class SliderComponent implements OnInit, AfterViewInit, OnChanges, OnDest
     // This both improves performance and makes CSS animations work correctly
     if (this.ticks && this.ticks.length === newTicks.length) {
       for (let i: number = 0; i  < newTicks.length; ++i) {
-        Object.assign(this.ticks[i], newTicks[i]);
+        this.ticks[i] = newTicks[i];
       }
     } else {
       this.ticks = newTicks;


### PR DESCRIPTION
Fix for #105 

In slider.component.ts in `updateTicksScale()` method, on line `#1246`,` Object.assign(this.ticks[i], newTicks[i])` was used to replace existing tick with the new tick at the given index.

Doing so, didn't removed the value of the tick from the old object even when the value was not present in the new tick. Thus, the tick tooltips still appeared.

That line was changed to `this.ticks[i] = newTicks[i]` instead of using `Object.assign()`.